### PR TITLE
Added NRE check for OfHoraxCult

### DIFF
--- a/1.5/Source/Need_Sanity.cs
+++ b/1.5/Source/Need_Sanity.cs
@@ -101,7 +101,13 @@ namespace VAEInsanity
 
         public override void SetInitialLevel()
         {
-            if (pawn.Faction == Faction.OfHoraxCult 
+            bool isHoraxCult = false;
+            if (Current.Game?.World != null && Find.FactionManager != null)
+            {
+                isHoraxCult = pawn.Faction == Find.FactionManager.OfHoraxCult;
+            }
+
+            if (isHoraxCult
                 || pawn.HasTrait(TraitDefOf.VoidFascination)
                 || pawn.HasTrait(TraitDefOf.Occultist)
                 || pawn.Inhumanized())


### PR DESCRIPTION
When loading the game I got NREs for some stranger pawns from this method, like the VQEGenerator's Genetron.inventor. After investigating it turned out that OfHoraxCult can result in NREs thrown by the game if the World and/or FactionManager have not finished initializing yet. I don't know if this is really the most elegant way to solve it, it feels hacky, but at least it fixed the on load errors for me.
Of course feel free to find a more elegant solution.

Example NRE:

Error while determining if Simi should have Need VAEI_Sanity: System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation. ---> System.NullReferenceException: Object reference not set to an instance of an object
[Ref 14A6023F]
 at Verse.Find.get_FactionManager () [0x00005] in <630e2863bc9a4a3493f2eff01e3a9556>:0 
 at RimWorld.Faction.get_OfHoraxCult () [0x00000] in <630e2863bc9a4a3493f2eff01e3a9556>:0 
 at VAEInsanity.Need_Sanity.SetInitialLevel () [0x0000b] in <119f25212aea441a9a34f4af559e462e>:0 
 at <0x27c5258baa0 + 0x00036> <unknown method>
 at <0x27c5258e140 + 0x000d2> <unknown method>
 at (wrapper managed-to-native) System.Reflection.MonoCMethod.InternalInvoke(System.Reflection.MonoCMethod,object,object[],System.Exception&)
 at System.Reflection.MonoCMethod.InternalInvoke (System.Object obj, System.Object[] parameters) [0x00002] in <eae584ce26bc40229c1b1aa476bfa589>:0 
   --- End of inner exception stack trace ---

Player Log
[Player-prev.log](https://github.com/user-attachments/files/19757660/Player-prev.log)
